### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = "npm start"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
+[![Run on Repl.it](https://repl.it/badge/github/mattk90/neobank-sample)](https://repl.it/github/mattk90/neobank-sample)
+
 ## Running the App
 
-1. Press run in the nivation bar and wait till it is fully started.
+1. Press run in the navation bar and wait till it is fully started.
 2. Open the App's Url in a new browser tab to access all features by Passbase
 
 ## Customizations


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).